### PR TITLE
Improved progress status reporting and post bake report

### DIFF
--- a/glim/src/lib.rs
+++ b/glim/src/lib.rs
@@ -1899,8 +1899,13 @@ fn render_lightmaps3(app: &mut Glim) {
         Some(oidn.unwrap())
     };
 
-    let process_lightmap = |group_index: usize, lightmap_type: u32| {
+    let process_lightmap = |group_index: usize, lightmap_type: u32, post_step: u32, post_total: u32| {
         let group = &app.groups[group_index].settings;
+
+        (log)(LogMessage::progress(
+            &format!("Denoising & Fixing Seams ({}/{})", post_step, post_total),
+            post_step as f32 / post_total as f32,
+        ));
 
         let mut compaction_push = CompactionPushConstants {
             width: group.width,
@@ -2035,14 +2040,24 @@ fn render_lightmaps3(app: &mut Glim) {
         };
     };
 
+    let lightmaps_per_group = match app.config.lightmap_mode {
+        LightmapMode::NonDirectional => 1,
+        LightmapMode::Directional => 2,
+    };
+    let post_total = (app.groups.len() * lightmaps_per_group).max(1) as u32;
+    let mut post_step = 0;
+
     for group_index in 0..app.groups.len() {
         match app.config.lightmap_mode {
             LightmapMode::NonDirectional => {
-                process_lightmap(group_index, 0);
+                post_step += 1;
+                process_lightmap(group_index, 0, post_step, post_total);
             }
             LightmapMode::Directional => {
-                process_lightmap(group_index, 0);
-                process_lightmap(group_index, 1);
+                post_step += 1;
+                process_lightmap(group_index, 0, post_step, post_total);
+                post_step += 1;
+                process_lightmap(group_index, 1, post_step, post_total);
             }
         }
     }

--- a/unity/Editor/Bake.cs
+++ b/unity/Editor/Bake.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -11,6 +12,17 @@ using UnityEngine.Rendering;
 
 namespace glim
 {
+    [Serializable]
+    public class BakeReport
+    {
+        public double bakeTime;
+        public int lightmapCount;
+        public long lightmapBytes;
+        public long lightmapMemoryBytes;
+        public long lightingDataBytes;
+        public int probeCount;
+    }
+
     public class Bake
     {
         class ReadbackResult
@@ -75,6 +87,53 @@ namespace glim
         }
 
         static double _bakeStartTime = 0.0;
+        
+        static readonly MethodInfo StorageMemorySize = typeof(Editor).Assembly
+            .GetType("UnityEditor.TextureUtil")?
+            .GetMethod("GetStorageMemorySizeLong", BindingFlags.Static | BindingFlags.NonPublic);
+
+        static long GetCompressedTextureBytes(Texture2D texture)
+        {
+            if (texture == null || StorageMemorySize == null)
+            {
+                return 0;
+            }
+
+            return (long)StorageMemorySize.Invoke(null, new object[] { texture });
+        }
+
+        static string BakeReportPath(string scenePath)
+        {
+            var dir = Path.GetDirectoryName(scenePath);
+            var sceneName = Path.GetFileNameWithoutExtension(scenePath);
+            return Path.Combine(dir, sceneName, "bakeReport.json");
+        }
+
+        public static BakeReport LoadReport(string scenePath)
+        {
+            if (string.IsNullOrEmpty(scenePath))
+            {
+                return null;
+            }
+
+            var path = BakeReportPath(scenePath);
+            return File.Exists(path) ? JsonUtility.FromJson<BakeReport>(File.ReadAllText(path)) : null;
+        }
+
+        public static int ReportVersion { get; private set; }
+
+        static void SaveReport(string scenePath, BakeReport report)
+        {
+            if (string.IsNullOrEmpty(scenePath))
+            {
+                return;
+            }
+
+            var path = BakeReportPath(scenePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, JsonUtility.ToJson(report));
+            ReportVersion++;
+        }
 
         const string BakingTitle = "Baking Lightmaps";
         const string DenoisingTitle = "Denoising & Fixing Seams";
@@ -141,6 +200,8 @@ namespace glim
                 }
 
                 bool hasDirectional = false;
+                long lightmapBytes = 0;
+                long lightmapMemoryBytes = 0;
                 foreach (var result in _bakeResults)
                 {
                     var data = result.data;
@@ -197,8 +258,12 @@ namespace glim
 
 
 
+                    lightmapBytes += new FileInfo(path).Length;
+
                     AssetDatabase.ImportAsset(path);
                     var loadedAsset = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+
+                    lightmapMemoryBytes += GetCompressedTextureBytes(loadedAsset);
 
                     if (directional)
                     {
@@ -286,6 +351,16 @@ namespace glim
 
                 LightmapSettings.lightmaps = lightmapDatas.ToArray();
                 LightmapSettings.lightmapsMode = hasDirectional ? LightmapsMode.CombinedDirectional : LightmapsMode.NonDirectional;
+
+                SaveReport(scenePath, new BakeReport
+                {
+                    bakeTime = now - _bakeStartTime,
+                    lightmapCount = _bakeResults.Count,
+                    lightmapBytes = lightmapBytes,
+                    lightmapMemoryBytes = lightmapMemoryBytes,
+                    lightingDataBytes = new FileInfo(destPath).Length,
+                    probeCount = _bakeProbesResults.Count,
+                });
 
                 LightmapBakerEditor.BakeAllReflectionProbesSnapshots(_context.scene, _context.reflectionProbesSuperSampling ? 2 : 1, _context.reflectionProbesSpecular);
             }

--- a/unity/Editor/Bake.cs
+++ b/unity/Editor/Bake.cs
@@ -16,6 +16,7 @@ namespace glim
     public class BakeReport
     {
         public double bakeTime;
+        public string finishedAt;
         public int lightmapCount;
         public long lightmapBytes;
         public long lightmapMemoryBytes;
@@ -355,6 +356,7 @@ namespace glim
                 SaveReport(scenePath, new BakeReport
                 {
                     bakeTime = now - _bakeStartTime,
+                    finishedAt = DateTime.Now.ToString("o"),
                     lightmapCount = _bakeResults.Count,
                     lightmapBytes = lightmapBytes,
                     lightmapMemoryBytes = lightmapMemoryBytes,

--- a/unity/Editor/Bake.cs
+++ b/unity/Editor/Bake.cs
@@ -89,9 +89,17 @@ namespace glim
 
         static double _bakeStartTime = 0.0;
         
-        static readonly MethodInfo StorageMemorySize = typeof(Editor).Assembly
-            .GetType("UnityEditor.TextureUtil")?
-            .GetMethod("GetStorageMemorySizeLong", BindingFlags.Static | BindingFlags.NonPublic);
+        static readonly MethodInfo StorageMemorySize = ResolveStorageMemorySize();
+
+        static MethodInfo ResolveStorageMemorySize()
+        {
+            var type = AppDomain.CurrentDomain.GetAssemblies()
+                .Select(a => a.GetType("UnityEditor.TextureUtil", false))
+                .FirstOrDefault(t => t != null);
+
+            return type?.GetMethod("GetStorageMemorySizeLong",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        }
 
         static long GetCompressedTextureBytes(Texture2D texture)
         {

--- a/unity/Editor/Bake.cs
+++ b/unity/Editor/Bake.cs
@@ -25,6 +25,14 @@ namespace glim
         static volatile bool _running = false;
         static int _progressID = -1;
         static BakeContext _context = null;
+        
+        static volatile float _progress = 0f;
+        static volatile string _progressMessage = "";
+        static volatile bool _isPreview = false;
+        
+        public static bool IsBaking => _running && !_isPreview;
+        public static float BakeProgress => _progress;
+        public static string BakeMessage => _progressMessage;
 
         [AOT.MonoPInvokeCallback(typeof(Bindings.LightmapReadCallback))]
         public static void OnReadbackLightmap(Bindings.LightmapReadbackData data)
@@ -61,7 +69,8 @@ namespace glim
             }
             if (data.ty == 2) // progress
             {
-                Progress.Report(_progressID, data.progress, data.message.ToString());
+                _progress = data.progress;
+                _progressMessage = data.message.ToString();
             }
         }
 
@@ -71,6 +80,10 @@ namespace glim
         {
             if (!_isComplete)
             {
+                if (_progressID != -1)
+                {
+                    Progress.Report(_progressID, _progress, _progressMessage);
+                }
                 return;
             }
 
@@ -268,6 +281,9 @@ namespace glim
             _isComplete = false;
             _running = false;
             _context = null;
+            _progress = 0f;
+            _progressMessage = "";
+            _isPreview = false;
             if (_progressID != -1)
             {
                 Progress.Finish(_progressID, Progress.Status.Succeeded);
@@ -397,6 +413,17 @@ namespace glim
         }
 #endif
 
+        // Refocus the window for QoL
+        static void RestoreSelection()
+        {
+            var baker = UnityEngine.Object.FindAnyObjectByType<LightmapBaker>();
+
+            if (baker != null)
+            {
+                Selection.activeGameObject = baker.gameObject;
+            }
+        }
+
         public static void Start(LightmapBaker baker, Bindings.GlimConfig config)
         {
             if (_running)
@@ -418,10 +445,12 @@ namespace glim
             _context = ctx;
 
             _running = true;
+            _isPreview = config.is_preview;
 
             if (!config.is_preview)
             {
                 _progressID = Progress.Start("Baking Lightmaps", null, Progress.Options.None);
+                RestoreSelection();
             }
 
 

--- a/unity/Editor/Bake.cs
+++ b/unity/Editor/Bake.cs
@@ -76,13 +76,35 @@ namespace glim
 
         static double _bakeStartTime = 0.0;
 
+        const string BakingTitle = "Baking Lightmaps";
+        const string DenoisingTitle = "Denoising & Fixing Seams";
+
+        static string _progressTitle = "";
+
+        static void ReportProgress()
+        {
+            var message = _progressMessage;
+
+            // redraw since we can't edit titles for progress
+            var title = message.StartsWith(DenoisingTitle) ? DenoisingTitle : BakingTitle;
+
+            if (title != _progressTitle)
+            {
+                Progress.Finish(_progressID, Progress.Status.Succeeded);
+                _progressID = Progress.Start(title, null, Progress.Options.None);
+                _progressTitle = title;
+            }
+
+            Progress.Report(_progressID, _progress, message);
+        }
+
         static void PollBakeComplete()
         {
             if (!_isComplete)
             {
                 if (_progressID != -1)
                 {
-                    Progress.Report(_progressID, _progress, _progressMessage);
+                    ReportProgress();
                 }
                 return;
             }
@@ -283,6 +305,7 @@ namespace glim
             _context = null;
             _progress = 0f;
             _progressMessage = "";
+            _progressTitle = "";
             _isPreview = false;
             if (_progressID != -1)
             {
@@ -449,7 +472,8 @@ namespace glim
 
             if (!config.is_preview)
             {
-                _progressID = Progress.Start("Baking Lightmaps", null, Progress.Options.None);
+                _progressID = Progress.Start(BakingTitle, null, Progress.Options.None);
+                _progressTitle = BakingTitle;
                 RestoreSelection();
             }
 

--- a/unity/Editor/LightmapBakerEditor.cs
+++ b/unity/Editor/LightmapBakerEditor.cs
@@ -184,6 +184,37 @@ namespace glim
                 };
                 root.Add(progressBar);
 
+                Label report = new()
+                {
+                    style =
+                    {
+                        whiteSpace = WhiteSpace.Normal,
+                        marginTop = 8
+                    }
+                };
+                root.Add(report);
+
+                void RefreshReport()
+                {
+                    var last = Bake.LoadReport(baker.gameObject.scene.path);
+                    report.style.display = last == null ? DisplayStyle.None : DisplayStyle.Flex;
+
+                    if (last == null)
+                    {
+                        return;
+                    }
+
+                    report.text =
+                        $"Last Bake: {last.bakeTime:0.00}s\n" +
+                        $"Lightmaps: {last.lightmapCount} ({EditorUtility.FormatBytes(last.lightmapBytes)} on disk, " +
+                        $"{EditorUtility.FormatBytes(last.lightmapMemoryBytes)} compressed)\n" +
+                        $"Lighting Data: {EditorUtility.FormatBytes(last.lightingDataBytes)}\n" +
+                        $"Light Probes: {last.probeCount}";
+                }
+
+                RefreshReport();
+
+                int seenReport = Bake.ReportVersion;
                 progressBar.schedule.Execute(() =>
                 {
                     bool running = Bake.IsBaking;
@@ -194,6 +225,12 @@ namespace glim
                     {
                         progressBar.value = Mathf.Clamp01(Bake.BakeProgress) * 100f;
                         progressBar.title = Bake.BakeMessage;
+                    }
+
+                    if (seenReport != Bake.ReportVersion)
+                    {
+                        seenReport = Bake.ReportVersion;
+                        RefreshReport();
                     }
                 }).Every(100);
             }

--- a/unity/Editor/LightmapBakerEditor.cs
+++ b/unity/Editor/LightmapBakerEditor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -204,8 +205,11 @@ namespace glim
                         return;
                     }
 
+                    var finishedAt = DateTime.Parse(last.finishedAt).ToString("HH:mm:ss");
+                    var took = TimeSpan.FromSeconds(last.bakeTime).ToString(@"hh\:mm\:ss");
+
                     report.text =
-                        $"Last Bake: {last.bakeTime:0.00}s\n" +
+                        $"Bake finished at {finishedAt} and took {took}\n" +
                         $"Lightmaps: {last.lightmapCount} ({EditorUtility.FormatBytes(last.lightmapBytes)} on disk, " +
                         $"{EditorUtility.FormatBytes(last.lightmapMemoryBytes)} compressed)\n" +
                         $"Lighting Data: {EditorUtility.FormatBytes(last.lightingDataBytes)}\n" +

--- a/unity/Editor/LightmapBakerEditor.cs
+++ b/unity/Editor/LightmapBakerEditor.cs
@@ -173,6 +173,29 @@ namespace glim
                     Bake.Start(baker, config);
                 };
                 root.Add(button);
+
+                ProgressBar progressBar = new()
+                {
+                    style =
+                    {
+                        height = 20,
+                        display = DisplayStyle.None
+                    }
+                };
+                root.Add(progressBar);
+
+                progressBar.schedule.Execute(() =>
+                {
+                    bool running = Bake.IsBaking;
+                    progressBar.style.display = running ? DisplayStyle.Flex : DisplayStyle.None;
+                    button.SetEnabled(!running);
+
+                    if (running)
+                    {
+                        progressBar.value = Mathf.Clamp01(Bake.BakeProgress) * 100f;
+                        progressBar.title = Bake.BakeMessage;
+                    }
+                }).Every(100);
             }
 
             return root;


### PR DESCRIPTION
Changes
- Added nicer progress reporting for the bottom right corner of the editor (Background Tasks)

Added
- Added progress reporting on the LightmapBaker component itself
- For improved UX making sure the LightmapBaker's Gameobject gets reselected after starting a bake
- Added a post bake report in the LightmapBaker component, storing the report alongside the scene's lightmaps