### PR TITLE
Add cancel bake button

### DIFF
--- a/glim/src/bindings.rs
+++ b/glim/src/bindings.rs
@@ -4,6 +4,7 @@ use std::{
     path::PathBuf,
     ptr::{null, null_mut},
     slice,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use crate::{
@@ -188,8 +189,21 @@ fn handle_unwind_error(log_callback: LogCallback, err: Box<dyn Any + Send>) {
     (log_callback)(data);
 }
 
+// Atomic bool so compiler can be happy
+static CANCEL_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+pub fn is_cancelled() -> bool {
+    CANCEL_REQUESTED.load(Ordering::Relaxed)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn app_request_cancel() {
+    CANCEL_REQUESTED.store(true, Ordering::Relaxed);
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn app_new(config: GlimConfig, output_dir: FfiString) -> *mut Glim {
+    CANCEL_REQUESTED.store(false, Ordering::Relaxed);
     let result = catch_unwind(AssertUnwindSafe(|| {
         let output_dir = PathBuf::from(output_dir.to_string());
         let app = Glim::new(config.clone(), output_dir);

--- a/glim/src/lib.rs
+++ b/glim/src/lib.rs
@@ -1802,6 +1802,9 @@ fn render_lightmaps3(app: &mut Glim) {
     let progress_scale = 1.0 / progress_max as f32;
 
     for sample_index in 0..app.config.direct_samples {
+        if is_cancelled() {
+            break;
+        }
         bake_direct_push.sample_index = sample_index;
         (log)(LogMessage::progress(&message, progress * progress_scale));
         progress += 1.0;
@@ -1886,12 +1889,15 @@ fn render_lightmaps3(app: &mut Glim) {
             group_info_buffer.buffer,
         );
 
-        for bounce_index in 0..app.config.bounce_count {
+        'bounces: for bounce_index in 0..app.config.bounce_count {
             push.bounce_index = bounce_index;
 
             let message = format!("Baking Bounce {}", bounce_index + 1);
 
             for sample_index in 0..app.config.indirect_samples {
+                if is_cancelled() {
+                    break 'bounces;
+                }
                 push.sample_index = sample_index;
                 (log)(LogMessage::progress(&message, progress * progress_scale));
                 progress += 1.0;
@@ -2165,6 +2171,9 @@ fn render_lightmaps3(app: &mut Glim) {
     let mut post_step = 0;
 
     for group_index in 0..app.groups.len() {
+        if is_cancelled() {
+            break;
+        }
         match app.config.lightmap_mode {
             LightmapMode::NonDirectional => {
                 post_step += 1;
@@ -2187,7 +2196,7 @@ fn render_lightmaps3(app: &mut Glim) {
     drop(staging_buffer_lightmap);
 
     // light probes
-    if app.probes.len() > 0 {
+    if app.probes.len() > 0 && !is_cancelled() {
         let mut shader = load_bake_light_probes_shader(&app.vk, &app.constants);
 
         update_bake_light_probes_shader(
@@ -2288,4 +2297,8 @@ fn render_lightmaps3(app: &mut Glim) {
     drop(compacted_lightmap);
     drop(compaction_buffer);
     drop(group_info_buffer);
+
+    if is_cancelled() {
+        (log)(LogMessage::message("Bake cancelled by user."));
+    }
 }

--- a/unity/Editor/Bake.cs
+++ b/unity/Editor/Bake.cs
@@ -34,10 +34,22 @@ namespace Glim
         static volatile float _progress = 0f;
         static volatile string _progressMessage = "";
         static volatile bool _isPreview = false;
+        static volatile bool _cancelRequested = false;
 
         public static bool IsBaking => _running && !_isPreview;
+        public static bool IsCancelling => _cancelRequested && _running;
         public static float BakeProgress => _progress;
         public static string BakeMessage => _progressMessage;
+
+        public static void Cancel()
+        {
+            if (!_running || _isPreview || _cancelRequested)
+            {
+                return;
+            }
+            _cancelRequested = true;
+            Bindings.app_request_cancel();
+        }
 
         [AOT.MonoPInvokeCallback(typeof(Bindings.ReadbackProbesCallback))]
         public static void OnReadbackLightprobes(Bindings.LightprobesReadbackData data)
@@ -139,6 +151,7 @@ namespace Glim
             {
                 Progress.Finish(_progressID, Progress.Status.Succeeded);
                 _progressID = Progress.Start(title, null, Progress.Options.None);
+                Progress.RegisterCancelCallback(_progressID, () => { Cancel(); return true; });
                 _progressTitle = title;
             }
 
@@ -158,6 +171,18 @@ namespace Glim
 
             if (_context.isPreview)
             {
+                ResetBake();
+                return;
+            }
+
+            if (_cancelRequested)
+            {
+                Debug.Log("Bake cancelled");
+                if (_progressID != -1)
+                {
+                    Progress.Finish(_progressID, Progress.Status.Canceled);
+                    _progressID = -1;
+                }
                 ResetBake();
                 return;
             }
@@ -346,6 +371,7 @@ namespace Glim
             _progressMessage = "";
             _progressTitle = "";
             _isPreview = false;
+            _cancelRequested = false;
             if (_progressID != -1)
             {
                 Progress.Finish(_progressID, Progress.Status.Succeeded);
@@ -512,6 +538,7 @@ namespace Glim
             if (!config.is_preview)
             {
                 _progressID = Progress.Start(BakingTitle, null, Progress.Options.None);
+                Progress.RegisterCancelCallback(_progressID, () => { Cancel(); return true; });
                 _progressTitle = BakingTitle;
                 RestoreSelection();
             }

--- a/unity/Editor/Bindings.cs
+++ b/unity/Editor/Bindings.cs
@@ -128,6 +128,9 @@ namespace Glim
         public static extern void app_run(IntPtr app);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void app_request_cancel();
+
+        [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void app_destroy(IntPtr app);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/unity/Editor/LightmapBakerEditor.cs
+++ b/unity/Editor/LightmapBakerEditor.cs
@@ -194,7 +194,15 @@ namespace Glim
                         display = DisplayStyle.None
                     }
                 };
-                cancelButton.clicked += Bake.Cancel;
+                cancelButton.clicked += () =>
+                {
+                    if (EditorUtility.DisplayDialog("Cancel Bake",
+                            "Are you sure you want to cancel the current bake?",
+                            "Cancel Bake", "Keep Baking"))
+                    {
+                        Bake.Cancel();
+                    }
+                };
                 root.Add(cancelButton);
 
                 Label report = new()

--- a/unity/Editor/LightmapBakerEditor.cs
+++ b/unity/Editor/LightmapBakerEditor.cs
@@ -185,6 +185,18 @@ namespace Glim
                 };
                 root.Add(progressBar);
 
+                Button cancelButton = new()
+                {
+                    text = "Cancel Bake",
+                    style =
+                    {
+                        height = 25,
+                        display = DisplayStyle.None
+                    }
+                };
+                cancelButton.clicked += Bake.Cancel;
+                root.Add(cancelButton);
+
                 Label report = new()
                 {
                     style =
@@ -223,12 +235,17 @@ namespace Glim
                 {
                     bool running = Bake.IsBaking;
                     progressBar.style.display = running ? DisplayStyle.Flex : DisplayStyle.None;
+                    cancelButton.style.display = running ? DisplayStyle.Flex : DisplayStyle.None;
                     button.SetEnabled(!running);
 
                     if (running)
                     {
                         progressBar.value = Mathf.Clamp01(Bake.BakeProgress) * 100f;
                         progressBar.title = Bake.BakeMessage;
+
+                        bool cancelling = Bake.IsCancelling;
+                        cancelButton.SetEnabled(!cancelling);
+                        cancelButton.text = cancelling ? "Cancelling…" : "Cancel Bake";
                     }
 
                     if (seenReport != Bake.ReportVersion)


### PR DESCRIPTION
Added
- Added a app_request_cancel() and is_cancelled() to request cancel of a bake from C#, that requests a break out of the baking passes 
- Added a "Cancel Bake" button with a confirmation dialogue, shows up when a bake is running
- Added support of cancelling a bake out of the Unity's "Background Tasks" progress card