### PR TITLE
fix crash when an object has more submeshes than material slots

### DIFF
--- a/unity/Editor/MetaTexture.cs
+++ b/unity/Editor/MetaTexture.cs
@@ -276,7 +276,12 @@ namespace Glim
                             break;
                         }
 
-                        var mat = sharedMaterials[submeshIndex];
+                        if (sharedMaterials.Length == 0)
+                        {
+                            continue;
+                        }                           
+
+                        var mat = sharedMaterials[Mathf.Min(submeshIndex, sharedMaterials.Length - 1)];
 
                         if (!mat)
                         {


### PR DESCRIPTION
avoids IndexOutOfRangeException by using the last material for any extra submeshes, the same way they are rendered.